### PR TITLE
From 1-feature-회원-회원가입 into main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation 'jakarta.validation:jakarta.validation-api:3.1.1'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'

--- a/src/main/java/com/bookjob/BookjobApplication.java
+++ b/src/main/java/com/bookjob/BookjobApplication.java
@@ -2,8 +2,10 @@ package com.bookjob;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BookjobApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/bookjob/auth/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/bookjob/auth/config/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.bookjob.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/bookjob/auth/config/SecurityConfig.java
+++ b/src/main/java/com/bookjob/auth/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package com.bookjob.auth.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:8080"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT", "PATCH", "DELETE","OPTIONS"));
+        configuration.setMaxAge(60L);
+        configuration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // 필터링에서 제외할 요청들
+        final RequestMatcher ignoredRequests = new OrRequestMatcher(
+                List.of(new AntPathRequestMatcher("/api/v1/members/signup", HttpMethod.POST.name())
+                ));
+
+        // 요청별 권한 관리
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(ignoredRequests).permitAll()
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // 정적 리소스 허용
+                .requestMatchers(HttpMethod.GET, "/ping", "/error", "/actuator/health").permitAll() // 헬스 체크 허용
+                .anyRequest().permitAll() // 이후 수정 필요. 개발 위해 permitAll 해둔 상황
+        );
+
+        // CSRF 비활성화 및 CORS 설정
+        http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()));
+
+        // 세션 비활성화 (JWT 사용)
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // 로그인 폼 비활성화
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/bookjob/common/domain/BaseEntity.java
+++ b/src/main/java/com/bookjob/common/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.bookjob.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/bookjob/common/domain/Password.java
+++ b/src/main/java/com/bookjob/common/domain/Password.java
@@ -1,0 +1,27 @@
+package com.bookjob.common.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+@Embeddable
+public class Password {
+    private String password;
+    protected Password() {}
+
+    private Password(String password) {
+        this.password = password;
+    }
+
+    public static Password of(String rawPassword, PasswordEncoder passwordEncoder) {
+        if (rawPassword == null || rawPassword.isEmpty()) {
+            throw new IllegalArgumentException("Password cannot be empty");
+        }
+        return new Password(passwordEncoder.encode(rawPassword));
+    }
+
+    public boolean matches(String rawPassword, PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(rawPassword, this.password);
+    }
+}

--- a/src/main/java/com/bookjob/common/dto/CommonResponse.java
+++ b/src/main/java/com/bookjob/common/dto/CommonResponse.java
@@ -1,0 +1,22 @@
+package com.bookjob.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CommonResponse<T>(int status, String message, T data) {
+
+    public static <T> CommonResponse<T> success() {
+        return new CommonResponse<>(HttpStatus.OK.value(), "성공", null);
+    }
+
+    public static <T> CommonResponse<T> success(T data) {
+        return new CommonResponse<>(HttpStatus.OK.value(), "성공", data);
+    }
+
+    public static <T> CommonResponse<T> failure(HttpStatusCode status, String message) {
+        return new CommonResponse<>(status.value(), message, null);
+    }
+}
+

--- a/src/main/java/com/bookjob/common/dto/CommonResponse.java
+++ b/src/main/java/com/bookjob/common/dto/CommonResponse.java
@@ -1,22 +1,27 @@
 package com.bookjob.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CommonResponse<T>(int status, String message, T data) {
+public record CommonResponse<T>(String message, T data, String timestamp) {
 
     public static <T> CommonResponse<T> success() {
-        return new CommonResponse<>(HttpStatus.OK.value(), "성공", null);
+        return new CommonResponse<>("성공", null, setCurrentTimestamp());
     }
 
     public static <T> CommonResponse<T> success(T data) {
-        return new CommonResponse<>(HttpStatus.OK.value(), "성공", data);
+        return new CommonResponse<>("성공", data, setCurrentTimestamp());
     }
 
-    public static <T> CommonResponse<T> failure(HttpStatusCode status, String message) {
-        return new CommonResponse<>(status.value(), message, null);
+    public static <T> CommonResponse<T> failure(String message) {
+        return new CommonResponse<>(message, null, setCurrentTimestamp());
+    }
+
+    private static String setCurrentTimestamp() {
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 }
 

--- a/src/main/java/com/bookjob/common/exception/BaseException.java
+++ b/src/main/java/com/bookjob/common/exception/BaseException.java
@@ -1,0 +1,14 @@
+package com.bookjob.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+public class BaseException extends RuntimeException {
+    private final HttpStatusCode status;
+
+    public BaseException(String message, HttpStatusCode status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/bookjob/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bookjob/common/exception/GlobalExceptionHandler.java
@@ -51,6 +51,6 @@ public class GlobalExceptionHandler {
     private static ResponseEntity<CommonResponse<Void>> buildResponseEntity(HttpStatusCode statusCode, String message) {
         return ResponseEntity
                 .status(statusCode)
-                .body(CommonResponse.failure(statusCode, message));
+                .body(CommonResponse.failure(message));
     }
 }

--- a/src/main/java/com/bookjob/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bookjob/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.bookjob.common.exception;
+
+import com.bookjob.common.dto.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public final ResponseEntity<CommonResponse<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
+
+        log.info("source = {} {}, message = {}",
+                request.getMethod(), request.getRequestURI(), ex.getMessage());
+
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+        String errorMessage = fieldErrors.stream()
+                .map(error -> String.format("%s: %s", error.getField(), error.getDefaultMessage()))
+                .collect(Collectors.joining(", "));
+
+        return buildResponseEntity(HttpStatus.BAD_REQUEST, errorMessage);
+    }
+
+    @ExceptionHandler(BaseException.class)
+    public final ResponseEntity<CommonResponse<Void>> handleBookjobException(BaseException e, HttpServletRequest request) {
+        log.warn("source = {} {}, message = {}",
+                request.getMethod(), request.getRequestURI(), e.getMessage());
+        return buildResponseEntity(e.getStatus(), e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public final ResponseEntity<CommonResponse<Void>> handleDefaultExceptions(Exception e, HttpServletRequest request) {
+        log.error("source = {} {}, message = {}",
+                request.getMethod(), request.getRequestURI(), e.getMessage(), e);
+        return buildResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
+    }
+
+    private static ResponseEntity<CommonResponse<Void>> buildResponseEntity(HttpStatusCode statusCode, String message) {
+        return ResponseEntity
+                .status(statusCode)
+                .body(CommonResponse.failure(statusCode, message));
+    }
+}

--- a/src/main/java/com/bookjob/member/MemberFacade/MemberFacade.java
+++ b/src/main/java/com/bookjob/member/MemberFacade/MemberFacade.java
@@ -1,0 +1,16 @@
+package com.bookjob.member.MemberFacade;
+
+import com.bookjob.member.dto.MemberSignupRequest;
+import com.bookjob.member.service.MemberWriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberFacade {
+    private final MemberWriteService memberWriteService;
+
+    public void saveMember(MemberSignupRequest request) {
+        memberWriteService.registerMember(request);
+    }
+}

--- a/src/main/java/com/bookjob/member/controller/MemberController.java
+++ b/src/main/java/com/bookjob/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.bookjob.member.controller;
+
+import com.bookjob.common.dto.CommonResponse;
+import com.bookjob.member.MemberFacade.MemberFacade;
+import com.bookjob.member.dto.MemberSignupRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberFacade memberFacade;
+
+    @PostMapping("/signup")
+    public ResponseEntity<CommonResponse<Void>> signup(@Valid @RequestBody MemberSignupRequest request) {
+        memberFacade.saveMember(request);
+
+        return ResponseEntity.ok(CommonResponse.success());
+    }
+}

--- a/src/main/java/com/bookjob/member/domain/Member.java
+++ b/src/main/java/com/bookjob/member/domain/Member.java
@@ -1,0 +1,56 @@
+package com.bookjob.member.domain;
+
+import com.bookjob.common.domain.BaseEntity;
+import com.bookjob.common.domain.Password;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Embedded
+    @Column(nullable = false)
+    private Password password;
+
+    private String provider;
+
+    private String providerId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
+    @Column(nullable = false)
+    private Boolean isBlocked;
+
+    @Builder
+    public Member (String loginId, String nickname, String email, Password password) {
+        this.loginId = loginId;
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.role = MemberRole.MEMBER;
+        this.isDeleted = false;
+        this.isBlocked = false;
+    }
+}

--- a/src/main/java/com/bookjob/member/domain/MemberRole.java
+++ b/src/main/java/com/bookjob/member/domain/MemberRole.java
@@ -1,0 +1,11 @@
+package com.bookjob.member.domain;
+
+public enum MemberRole {
+    MEMBER ("회원");
+
+    private String name;
+
+    MemberRole(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/bookjob/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/bookjob/member/dto/MemberSignupRequest.java
@@ -1,0 +1,25 @@
+package com.bookjob.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MemberSignupRequest(
+        @NotBlank(message = "아이디는 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]{4,12}$", message = "아이디는 영문과 숫자만 사용하며, 4~12자까지 입력 가능합니다.")
+        String loginId,
+
+        @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,8}$", message = "닉네임은 특수문자를 제외한 2~8자까지 입력 가능합니다.")
+        String nickname,
+
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        @Email(message = "이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d).+$", message = "비밀번호는 영문과 숫자를 포함해야 합니다.")
+        String password
+) {}

--- a/src/main/java/com/bookjob/member/repository/MemberRepository.java
+++ b/src/main/java/com/bookjob/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.bookjob.member.repository;
+
+import com.bookjob.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/bookjob/member/service/MemberWriteService.java
+++ b/src/main/java/com/bookjob/member/service/MemberWriteService.java
@@ -1,0 +1,29 @@
+package com.bookjob.member.service;
+
+import com.bookjob.common.domain.Password;
+import com.bookjob.member.domain.Member;
+import com.bookjob.member.dto.MemberSignupRequest;
+import com.bookjob.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberWriteService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void registerMember(MemberSignupRequest request) {
+
+        Member member = Member.builder()
+                .loginId(request.loginId())
+                .nickname(request.nickname())
+                .email(request.email())
+                .password(Password.of(request.password(), passwordEncoder))
+                .build();
+
+        memberRepository.save(member);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  application:
+    name: bookjob
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/bookjob
+    username: root
+    password: root
+  jpa:
+    open-in-view: false
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: create
+
+


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 프로젝트 기본 설정 추가
- 회원가입 생성

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| POST   | /api/v1/members/signup | 회원가입        |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. security config 현재 permit all로 되어 있음. 
2. 회원가입 시 입력 값은 다음의 조건을 따라야 함. 
- 아이디 (loginId): 영문, 숫자만 사용 가능 / 길이 4~12자
- 닉네임 (nickname): 특수문자 제외 / 길이 2~8자
- 이메일 (email): 이메일 형식
- 비밀번호 (password): 영문 + 숫자 포함 / 8자 이상
3. 테스트 코드는 아직 만들지 않음. 포스트맨만 확인. 
4. dev 브랜치 생성 필요. 기본 설정 공유를 위해 main에 바로 푸시함. 
5. api 문서 > 회원가입 > loginId 추가함. 

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
