### PR TITLE
From 15-feature-인증-아이디비밀번호-찾기 into dev

### DIFF
--- a/src/main/java/com/bookjob/auth/controller/AuthController.java
+++ b/src/main/java/com/bookjob/auth/controller/AuthController.java
@@ -87,4 +87,13 @@ public class AuthController {
         authFacade.sendCodeToEmailForPassword(request.email());
         return ResponseEntity.ok(CommonResponse.success());
     }
+
+    /**
+     * 비밀번호 찾기 시, 이메일 인증 요청
+     */
+    @PostMapping("/email-verification/pw/code")
+    public ResponseEntity<?> verifyCodeForPassword(@Valid @RequestBody EmailVerificationRequest request) {
+        authFacade.verifyCodeForPassword(request);
+        return ResponseEntity.ok(CommonResponse.success());
+    }
 }

--- a/src/main/java/com/bookjob/auth/controller/AuthController.java
+++ b/src/main/java/com/bookjob/auth/controller/AuthController.java
@@ -1,9 +1,9 @@
 package com.bookjob.auth.controller;
 
 import com.bookjob.auth.dto.FindLoginIdResponse;
+import com.bookjob.auth.dto.MaskedEmailResponse;
 import com.bookjob.auth.facade.AuthFacade;
 import com.bookjob.common.dto.CommonResponse;
-import com.bookjob.email.domain.EmailReason;
 import com.bookjob.email.dto.EmailRequest;
 import com.bookjob.email.dto.EmailVerificationRequest;
 import jakarta.validation.Valid;
@@ -68,4 +68,15 @@ public class AuthController {
         String maskedLoginId = authFacade.verifyCodeForLoginId(request);
         return ResponseEntity.ok(CommonResponse.success(new FindLoginIdResponse(maskedLoginId)));
     }
+
+    /**
+     * 비밀번호 찾기 시 아이디가 존재하는지 확인하는 API
+     */
+    @GetMapping("/exist-id")
+    public ResponseEntity<?> checkLoginIdExists(
+            @RequestParam(name = "loginId") @NotBlank(message = "아이디는 필수 입력값입니다.") String loginId) {
+        String maskedEmail = authFacade.checkLoginIdExists(loginId);
+        return ResponseEntity.ok(CommonResponse.success(new MaskedEmailResponse(maskedEmail)));
+    }
+
 }

--- a/src/main/java/com/bookjob/auth/controller/AuthController.java
+++ b/src/main/java/com/bookjob/auth/controller/AuthController.java
@@ -79,4 +79,12 @@ public class AuthController {
         return ResponseEntity.ok(CommonResponse.success(new MaskedEmailResponse(maskedEmail)));
     }
 
+    /**
+     * 비밀번호 찾기 시, 이메일 인증 요청
+     */
+    @PostMapping("/email-verification/pw")
+    public ResponseEntity<?> verifyCodeForPassword(@Valid @RequestBody EmailRequest request) {
+        authFacade.sendCodeToEmailForPassword(request.email());
+        return ResponseEntity.ok(CommonResponse.success());
+    }
 }

--- a/src/main/java/com/bookjob/auth/controller/AuthController.java
+++ b/src/main/java/com/bookjob/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.bookjob.auth.controller;
 import com.bookjob.auth.dto.FindLoginIdResponse;
 import com.bookjob.auth.facade.AuthFacade;
 import com.bookjob.common.dto.CommonResponse;
+import com.bookjob.email.domain.EmailReason;
 import com.bookjob.email.dto.EmailRequest;
 import com.bookjob.email.dto.EmailVerificationRequest;
 import jakarta.validation.Valid;
@@ -59,6 +60,9 @@ public class AuthController {
         return ResponseEntity.ok(CommonResponse.success());
     }
 
+    /**
+     * 아이디 찾기 시 인증 번호 입력 후 확인 요청
+     */
     @PostMapping("/email-verification/id/code")
     public ResponseEntity<?> verifyCodeForLoginId(@Valid @RequestBody EmailVerificationRequest request) {
         String maskedLoginId = authFacade.verifyCodeForLoginId(request);

--- a/src/main/java/com/bookjob/auth/controller/AuthController.java
+++ b/src/main/java/com/bookjob/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.bookjob.auth.controller;
 
+import com.bookjob.auth.dto.FindLoginIdResponse;
 import com.bookjob.auth.facade.AuthFacade;
 import com.bookjob.common.dto.CommonResponse;
 import com.bookjob.email.dto.EmailRequest;
@@ -17,14 +18,20 @@ public class AuthController {
 
     private final AuthFacade authFacade;
 
+    /**
+     * 회원 가입 시 이메일 인증 번호 요청
+     */
     @PostMapping("/emails")
     public ResponseEntity<?> sendCodeToEmail(@Valid @RequestBody EmailRequest request) {
         authFacade.sendCodeToEmail(request.email());
         return ResponseEntity.ok(CommonResponse.success());
     }
 
+    /**
+     * 회원 가입 시 인증 번호 입력 후 확인 요청
+     */
     @PostMapping("/emails/code")
-    public ResponseEntity<?> verificationEmail(@Valid @RequestBody EmailVerificationRequest request) {
+    public ResponseEntity<?> verifyCode(@Valid @RequestBody EmailVerificationRequest request) {
         authFacade.verifyCode(request);
         return ResponseEntity.ok(CommonResponse.success());
     }
@@ -43,9 +50,18 @@ public class AuthController {
         return ResponseEntity.ok(CommonResponse.success());
     }
 
+    /**
+     * 아이디 찾기 시, 이메일 인증 요청
+     */
     @PostMapping("/email-verification/id")
     public ResponseEntity<?> sendCodeToEmailForLoginId(@Valid @RequestBody EmailRequest request) {
         authFacade.sendCodeToEmailForLoginId(request.email());
         return ResponseEntity.ok(CommonResponse.success());
+    }
+
+    @PostMapping("/email-verification/id/code")
+    public ResponseEntity<?> verifyCodeForLoginId(@Valid @RequestBody EmailVerificationRequest request) {
+        String maskedLoginId = authFacade.verifyCodeForLoginId(request);
+        return ResponseEntity.ok(CommonResponse.success(new FindLoginIdResponse(maskedLoginId)));
     }
 }

--- a/src/main/java/com/bookjob/auth/dto/FindLoginIdResponse.java
+++ b/src/main/java/com/bookjob/auth/dto/FindLoginIdResponse.java
@@ -1,0 +1,6 @@
+package com.bookjob.auth.dto;
+
+public record FindLoginIdResponse (
+        String loginId
+) {
+}

--- a/src/main/java/com/bookjob/auth/dto/MaskedEmailResponse.java
+++ b/src/main/java/com/bookjob/auth/dto/MaskedEmailResponse.java
@@ -1,0 +1,6 @@
+package com.bookjob.auth.dto;
+
+public record MaskedEmailResponse(
+        String maskedEmail
+) {
+}

--- a/src/main/java/com/bookjob/auth/facade/AuthFacade.java
+++ b/src/main/java/com/bookjob/auth/facade/AuthFacade.java
@@ -1,6 +1,7 @@
 package com.bookjob.auth.facade;
 
 import com.bookjob.auth.service.AuthService;
+import com.bookjob.email.domain.EmailReason;
 import com.bookjob.email.dto.EmailVerificationRequest;
 import com.bookjob.email.service.EmailService;
 import com.bookjob.member.service.MemberReadService;
@@ -17,7 +18,7 @@ public class AuthFacade {
 
     public void sendCodeToEmail(String email) {
         authService.checkDuplicatedEmail(email);
-        emailService.requestEmailVerification(email);
+        emailService.requestEmailVerification(email, EmailReason.REGISTER);
     }
 
     public void verifyCode(EmailVerificationRequest request) {
@@ -34,7 +35,7 @@ public class AuthFacade {
 
     public void sendCodeToEmailForLoginId(String email) {
         authService.doesEmailExist(email);
-        emailService.requestEmailVerification(email);
+        emailService.requestEmailVerification(email, EmailReason.LOGINID);
     }
 
     public String verifyCodeForLoginId(EmailVerificationRequest request) {

--- a/src/main/java/com/bookjob/auth/facade/AuthFacade.java
+++ b/src/main/java/com/bookjob/auth/facade/AuthFacade.java
@@ -42,4 +42,9 @@ public class AuthFacade {
         emailService.verifyCode(request);
         return memberReadService.getMaskedLoginId(request.email());
     }
+
+    public String checkLoginIdExists(String loginId) {
+        return memberReadService.getMaskedEmail(loginId);
+    }
+
 }

--- a/src/main/java/com/bookjob/auth/facade/AuthFacade.java
+++ b/src/main/java/com/bookjob/auth/facade/AuthFacade.java
@@ -51,4 +51,8 @@ public class AuthFacade {
         authService.doesEmailExist(email);
         emailService.requestEmailVerification(email, EmailReason.PASSWORD);
     }
+
+    public void verifyCodeForPassword(EmailVerificationRequest request) {
+        emailService.verifyCode(request);
+    }
 }

--- a/src/main/java/com/bookjob/auth/facade/AuthFacade.java
+++ b/src/main/java/com/bookjob/auth/facade/AuthFacade.java
@@ -3,6 +3,7 @@ package com.bookjob.auth.facade;
 import com.bookjob.auth.service.AuthService;
 import com.bookjob.email.dto.EmailVerificationRequest;
 import com.bookjob.email.service.EmailService;
+import com.bookjob.member.service.MemberReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,7 @@ public class AuthFacade {
 
     private final AuthService authService;
     private final EmailService emailService;
+    private final MemberReadService memberReadService;
 
     public void sendCodeToEmail(String email) {
         authService.checkDuplicatedEmail(email);
@@ -33,5 +35,10 @@ public class AuthFacade {
     public void sendCodeToEmailForLoginId(String email) {
         authService.doesEmailExist(email);
         emailService.requestEmailVerification(email);
+    }
+
+    public String verifyCodeForLoginId(EmailVerificationRequest request) {
+        emailService.verifyCode(request);
+        return memberReadService.getMaskedLoginId(request.email());
     }
 }

--- a/src/main/java/com/bookjob/auth/facade/AuthFacade.java
+++ b/src/main/java/com/bookjob/auth/facade/AuthFacade.java
@@ -47,4 +47,8 @@ public class AuthFacade {
         return memberReadService.getMaskedEmail(loginId);
     }
 
+    public void sendCodeToEmailForPassword(String email) {
+        authService.doesEmailExist(email);
+        emailService.requestEmailVerification(email, EmailReason.PASSWORD);
+    }
 }

--- a/src/main/java/com/bookjob/common/exception/NotFoundException.java
+++ b/src/main/java/com/bookjob/common/exception/NotFoundException.java
@@ -6,6 +6,7 @@ public class NotFoundException extends BaseException {
     static private final String EMAIL_NOT_FOUND = "이메일을 찾을 수 없습니다. ";
     static private final String BOARD_NOT_FOUND = "게시글을 찾을 수 없습니다. ";
     static private final String COMMENT_NOT_FOUND = "댓글을 찾을 수 없습니다.";
+    static private final String LOGINID_NOT_FOUND = "로그인 아이디를 찾을 수 없습니다.";
 
     public NotFoundException(String message) {
         super(message, HttpStatus.NOT_FOUND);
@@ -21,5 +22,9 @@ public class NotFoundException extends BaseException {
 
     public static NotFoundException commentNotFound() {
         return new NotFoundException(COMMENT_NOT_FOUND);
+    }
+
+    public static NotFoundException loginIdNotFound() {
+        return new NotFoundException(LOGINID_NOT_FOUND);
     }
 }

--- a/src/main/java/com/bookjob/email/domain/EmailReason.java
+++ b/src/main/java/com/bookjob/email/domain/EmailReason.java
@@ -1,0 +1,26 @@
+package com.bookjob.email.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum EmailReason {
+    REGISTER("회원가입"),
+    LOGINID("아이디 찾기"),
+    PASSWORD("비밀번호 찾기");
+
+    private final String reason;
+
+    EmailReason(String reason) {
+        this.reason = reason;
+    }
+
+    public static EmailReason fromString(String reason) {
+        for(EmailReason r : EmailReason.values()) {
+            if (r.getReason().equals(reason)) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/bookjob/email/domain/EmailVerification.java
+++ b/src/main/java/com/bookjob/email/domain/EmailVerification.java
@@ -23,10 +23,15 @@ public class EmailVerification {
     @Column(nullable = false)
     private LocalDateTime expirationTime;
 
-    public EmailVerification(String toEmail, String code, LocalDateTime expirationTime) {
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EmailReason reason;
+
+    public EmailVerification(String toEmail, String code, LocalDateTime expirationTime, EmailReason reason) {
         this.email = toEmail;
         this.code = code;
         this.expirationTime = expirationTime;
+        this.reason = reason;
     }
 
     public void update(String code, LocalDateTime expirationTime) {

--- a/src/main/java/com/bookjob/email/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/bookjob/email/dto/EmailVerificationRequest.java
@@ -9,6 +9,9 @@ public record EmailVerificationRequest (
         String email,
 
         @NotBlank
-        String code
+        String code,
+
+        @NotBlank
+        String reason
 ) {
 }

--- a/src/main/java/com/bookjob/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/bookjob/email/repository/EmailVerificationRepository.java
@@ -1,13 +1,15 @@
 package com.bookjob.email.repository;
 
+import com.bookjob.email.domain.EmailReason;
 import com.bookjob.email.domain.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
-    Optional<EmailVerification> findByEmailAndCode(String email, String code);
-    Optional<EmailVerification> findByEmail(String email);
-
     void deleteByEmail(String email);
+
+    Optional<EmailVerification> findByEmailAndReason(String toEmail, EmailReason register);
+
+    Optional<EmailVerification> findByEmailAndCodeAndReason(String email, String code, EmailReason reason);
 }

--- a/src/main/java/com/bookjob/member/domain/MemberRole.java
+++ b/src/main/java/com/bookjob/member/domain/MemberRole.java
@@ -1,11 +1,15 @@
 package com.bookjob.member.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum MemberRole {
     MEMBER ("회원");
 
-    private String name;
+    private final String name;
 
     MemberRole(String name) {
         this.name = name;
     }
+
 }

--- a/src/main/java/com/bookjob/member/repository/MemberRepository.java
+++ b/src/main/java/com/bookjob/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.bookjob.member.repository;
 
 import com.bookjob.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -15,4 +16,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByLoginId(String loginId);
 
     boolean existsByNickname(String nickname);
+
+    @Query("""
+    select m.loginId from Member m where m.email = :email
+    """)
+    String findLoginIdByEmail(String email);
 }

--- a/src/main/java/com/bookjob/member/repository/MemberRepository.java
+++ b/src/main/java/com/bookjob/member/repository/MemberRepository.java
@@ -21,4 +21,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     select m.loginId from Member m where m.email = :email
     """)
     String findLoginIdByEmail(String email);
+
+    @Query("""
+    select m.email from Member m where m.loginId = :loginId
+    """)
+    String findEmailByLoginId(String loginId);
 }

--- a/src/main/java/com/bookjob/member/service/MemberReadService.java
+++ b/src/main/java/com/bookjob/member/service/MemberReadService.java
@@ -1,10 +1,9 @@
 package com.bookjob.member.service;
 
+import com.bookjob.common.exception.NotFoundException;
 import com.bookjob.common.exception.UnAuthorizedException;
 import com.bookjob.member.domain.Member;
 import com.bookjob.member.repository.MemberRepository;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,8 +24,45 @@ public class MemberReadService {
 
     public String getMaskedLoginId(String email) {
         String loginId = memberRepository.findLoginIdByEmail(email);
+        if (loginId == null || loginId.isBlank()) {
+            throw NotFoundException.loginIdNotFound();
+        }
+
         int visible = 2;
         String maskedLoginId = "*".repeat(loginId.length() - visible);
         return loginId.substring(0, visible) + maskedLoginId;
+    }
+
+    public String getMaskedEmail(String loginId) {
+        String email = memberRepository.findEmailByLoginId(loginId);
+        if (email == null || email.isBlank()) {
+            throw NotFoundException.emailNotFound();
+        }
+
+        return maskEmail(email);
+    }
+
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf("@");
+
+        String localPart = email.substring(0, atIndex); // "abcde"
+        String domainPart = email.substring(atIndex + 1); // "domain.com"
+
+        // 마스킹된 local part
+        int visibleLocal = Math.min(2, localPart.length());
+        String maskedLocal = localPart.substring(0, visibleLocal)
+                + "*".repeat(localPart.length() - visibleLocal);
+
+        // 마스킹된 domain part
+        int dotIndex = domainPart.lastIndexOf(".");
+
+        String domainName = domainPart.substring(0, dotIndex); // "domain"
+        String domainSuffix = domainPart.substring(dotIndex);  // ".com"
+
+        int visibleDomain = 1;
+        String maskedDomain = domainName.substring(0, visibleDomain)
+                + "*".repeat(domainName.length() - visibleDomain);
+
+        return maskedLocal + "@" + maskedDomain + domainSuffix;
     }
 }

--- a/src/main/java/com/bookjob/member/service/MemberReadService.java
+++ b/src/main/java/com/bookjob/member/service/MemberReadService.java
@@ -3,18 +3,30 @@ package com.bookjob.member.service;
 import com.bookjob.common.exception.UnAuthorizedException;
 import com.bookjob.member.domain.Member;
 import com.bookjob.member.repository.MemberRepository;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberReadService {
 
     private final MemberRepository boardRepository;
+    private final MemberRepository memberRepository;
 
     public Member getActiveMemberById(Long id) {
         return boardRepository.findByIdAndIsBlockedFalseAndDeletedAtIsNull(id).orElseThrow(
                 UnAuthorizedException::deactivatedMemberUnauthorized
         );
+    }
+
+    public String getMaskedLoginId(String email) {
+        String loginId = memberRepository.findLoginIdByEmail(email);
+        int visible = 2;
+        String maskedLoginId = "*".repeat(loginId.length() - visible);
+        return loginId.substring(0, visible) + maskedLoginId;
     }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| POST   | /api/v1/auth/email-verification/id/code | 아이디찾기 인증번호 확인        |
| GET   | /api/v1/auth/exsit-id | 비밀번호찾기 아이디 확인        |
| POST   | /api/v1/auth/email-verification/pw | 비밀번호찾기 인증번호 요청        |
| POST   | /api/v1/auth/email-verification/pw/code | 비밀번호찾기 인증번호 확인        |

## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. 똑같은 파사드 메서드를 호출하는 컨트롤러가 있음. 인증번호 확인하는 쪽. 
- 일반 인증번호확인 + 비밀번호 인증번호확인. 
- 이후 요청/응답값이 달라질 경우를 고려하여 일단 분리해 놓음

2. 비밀번호 찾기 시, 아이디 존재여부 확인 -> 마스킹된 이메일 전달
- aaaaa@bbbbb.com -> a****@b****.com

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
