### PR TITLE
From 50-feature-회원-마이페이지-추가기능 into dev : 내가 쓴 구인구직글 관련 

### DIFF
--- a/src/main/java/com/bookjob/board/controller/BoardController.java
+++ b/src/main/java/com/bookjob/board/controller/BoardController.java
@@ -7,6 +7,8 @@ import com.bookjob.board.dto.response.CursorBoardResponse;
 import com.bookjob.board.facade.BoardFacade;
 import com.bookjob.common.dto.CommonResponse;
 import com.bookjob.member.domain.Member;
+import com.bookjob.member.dto.BoardIdsRequest;
+import com.bookjob.member.dto.MyPostingsInBoardResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -63,5 +65,21 @@ public class BoardController {
     @GetMapping("/best")
     public ResponseEntity<?> getBoardBest() {
         return ResponseEntity.ok(CommonResponse.success(boardFacade.getBoardBest()));
+    }
+
+    /**
+     * 내가 쓴 자유게시판 조회 및 선택 삭제
+     */
+    @GetMapping("/members")
+    public ResponseEntity<?> getMyPostingsInBoard(@AuthenticationPrincipal(expression = "member") Member member) {
+        MyPostingsInBoardResponse myPostingsInBoardResponse = boardFacade.getMyPostingsInBoard(member);
+        return ResponseEntity.ok(CommonResponse.success(myPostingsInBoardResponse));
+    }
+
+    @DeleteMapping("/members")
+    public ResponseEntity<?> deleteMyPostingsInBoard(@AuthenticationPrincipal(expression = "member") Member member,
+                                                     @Valid @RequestBody BoardIdsRequest request) {
+        boardFacade.deleteMyPostingsInBoard(member, request);
+        return ResponseEntity.ok(CommonResponse.success());
     }
 }

--- a/src/main/java/com/bookjob/board/facade/BoardFacade.java
+++ b/src/main/java/com/bookjob/board/facade/BoardFacade.java
@@ -8,6 +8,8 @@ import com.bookjob.board.dto.response.CursorBoardResponse;
 import com.bookjob.board.service.BoardReadService;
 import com.bookjob.board.service.BoardWriteService;
 import com.bookjob.member.domain.Member;
+import com.bookjob.member.dto.BoardIdsRequest;
+import com.bookjob.member.dto.MyPostingsInBoardResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -42,5 +44,13 @@ public class BoardFacade {
 
     public List<BoardBestResponse> getBoardBest() {
         return boardReadService.getBoardBest();
+    }
+
+    public MyPostingsInBoardResponse getMyPostingsInBoard(Member member) {
+        return boardReadService.getMyPostingsInBoard(member);
+    }
+
+    public void deleteMyPostingsInBoard(Member member, BoardIdsRequest request) {
+        boardWriteService.deleteMyPostingsInBoard(member, request);
     }
 }

--- a/src/main/java/com/bookjob/common/exception/BadRequestException.java
+++ b/src/main/java/com/bookjob/common/exception/BadRequestException.java
@@ -8,7 +8,10 @@ import java.util.stream.Collectors;
 public class BadRequestException extends BaseException {
     static private final String VERIFICATION_CODE_EXPIRED = "인증 시간이 초과되었습니다.";
     static private final String INVALID_VERIFICATION_CODE = "인증 번호가 일치하지 않습니다.";
+    static private final String INVALID_JOB_CATEGORY = "구인/구직 중 어느 카테고리에도 속하지 않습니다. : {%s}";
     static private final String INVALID_ENUM_VALUE = "유효하지 않은 값입니다.: {%s}, 유효한 값: {%s}";
+    static private final String JOB_POSTING_ALREADY_DELETED = "이미 삭제된 구인 글입니다.";
+    static private final String JOB_SEEKING_ALREADY_DELETED = "이미 삭제된 구직 글입니다.";
 
     public BadRequestException(String message) {
         super(message, HttpStatus.BAD_REQUEST);
@@ -22,6 +25,11 @@ public class BadRequestException extends BaseException {
         return new BadRequestException(INVALID_VERIFICATION_CODE);
     }
 
+    public static BadRequestException invalidJobCategory(String category) {
+        String message = String.format(INVALID_JOB_CATEGORY, category);
+        return new BadRequestException(message);
+    }
+
     public static <T extends Enum<T>> BadRequestException invalidEnumValue(String value, Class<T> enumClass) {
         String validValues = Arrays.stream(enumClass.getEnumConstants())
                 .map(Enum::name)
@@ -29,5 +37,13 @@ public class BadRequestException extends BaseException {
 
         String message = String.format(INVALID_ENUM_VALUE, value, validValues);
         return new BadRequestException(message);
+    }
+
+    public static BadRequestException JobPostingAlreadyDeleted() {
+        return new BadRequestException(JOB_POSTING_ALREADY_DELETED);
+    }
+
+    public static BadRequestException JobSeekingAlreadyDeleted() {
+        return new BadRequestException(JOB_SEEKING_ALREADY_DELETED);
     }
 }

--- a/src/main/java/com/bookjob/job/controller/RecruitmentController.java
+++ b/src/main/java/com/bookjob/job/controller/RecruitmentController.java
@@ -1,0 +1,38 @@
+package com.bookjob.job.controller;
+
+import com.bookjob.common.dto.CommonResponse;
+import com.bookjob.job.dto.request.RecruitmentIdsRequest;
+import com.bookjob.job.dto.response.MyPostingsInRecruitmentResponse;
+import com.bookjob.job.facade.RecruitmentFacade;
+import com.bookjob.member.domain.Member;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recruitments")
+public class RecruitmentController {
+
+    private final RecruitmentFacade recruitmentFacade;
+
+    /**
+     * 내가 쓴 구인구직글 조회 및 선택 삭제
+     */
+    @GetMapping("/members")
+    public ResponseEntity<?> getMyPostingsInRecruitments(@AuthenticationPrincipal(expression = "member") Member member,
+                                                         @RequestParam(required = false, defaultValue = "0") int page,
+                                                         @RequestParam(required = false, defaultValue = "10") int limit) {
+        MyPostingsInRecruitmentResponse myPostingsInBoardResponse = recruitmentFacade.getMyPostingsInRecruitments(member, page, limit);
+        return ResponseEntity.ok(CommonResponse.success(myPostingsInBoardResponse));
+    }
+
+    @DeleteMapping("/members")
+    public ResponseEntity<?> deleteMyPostingsInRecruitments(@AuthenticationPrincipal(expression = "member") Member member,
+                                                            @Valid @RequestBody RecruitmentIdsRequest request) {
+        recruitmentFacade.deleteMyPostingsInRecruitments(member, request);
+        return ResponseEntity.ok(CommonResponse.success());
+    }
+}

--- a/src/main/java/com/bookjob/job/domain/JobPosting.java
+++ b/src/main/java/com/bookjob/job/domain/JobPosting.java
@@ -1,6 +1,7 @@
 package com.bookjob.job.domain;
 
 import com.bookjob.common.domain.SoftDeleteEntity;
+import com.bookjob.common.exception.BadRequestException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -95,5 +96,12 @@ public class JobPosting extends SoftDeleteEntity {
         } else {
             this.viewCount++;
         }
+    }
+
+    public void softDelete() {
+        if (this.getDeletedAt() != null) {
+            throw BadRequestException.JobPostingAlreadyDeleted();
+        }
+        this.delete();
     }
 }

--- a/src/main/java/com/bookjob/job/domain/JobSeeking.java
+++ b/src/main/java/com/bookjob/job/domain/JobSeeking.java
@@ -1,6 +1,7 @@
 package com.bookjob.job.domain;
 
 import com.bookjob.common.domain.SoftDeleteEntity;
+import com.bookjob.common.exception.BadRequestException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -78,5 +79,12 @@ public class JobSeeking extends SoftDeleteEntity {
         this.jobCategory = jobCategory;
         this.contactEmail = contactEmail;
         this.experience = experience;
+    }
+
+    public void softDelete() {
+        if (this.getDeletedAt() != null) {
+            throw BadRequestException.JobSeekingAlreadyDeleted();
+        }
+        this.delete();
     }
 }

--- a/src/main/java/com/bookjob/job/dto/application/MyPostingsInRecruitment.java
+++ b/src/main/java/com/bookjob/job/dto/application/MyPostingsInRecruitment.java
@@ -1,0 +1,11 @@
+package com.bookjob.job.dto.application;
+
+import java.time.LocalDateTime;
+
+public record MyPostingsInRecruitment(
+        Long recruitmentId,
+        String title,
+        LocalDateTime createdAt,
+        String recruitmentCategory
+) {
+}

--- a/src/main/java/com/bookjob/job/dto/request/RecruitmentDeleteRequest.java
+++ b/src/main/java/com/bookjob/job/dto/request/RecruitmentDeleteRequest.java
@@ -1,0 +1,7 @@
+package com.bookjob.job.dto.request;
+
+public record RecruitmentDeleteRequest (
+        Long recruitmentId,
+        String recruitmentCategory
+) {
+}

--- a/src/main/java/com/bookjob/job/dto/request/RecruitmentIdsRequest.java
+++ b/src/main/java/com/bookjob/job/dto/request/RecruitmentIdsRequest.java
@@ -1,0 +1,8 @@
+package com.bookjob.job.dto.request;
+
+import java.util.List;
+
+public record RecruitmentIdsRequest (
+        List<RecruitmentDeleteRequest> deleteRequest
+) {
+}

--- a/src/main/java/com/bookjob/job/dto/response/MyPostingsInRecruitmentResponse.java
+++ b/src/main/java/com/bookjob/job/dto/response/MyPostingsInRecruitmentResponse.java
@@ -1,0 +1,10 @@
+package com.bookjob.job.dto.response;
+
+import com.bookjob.job.dto.application.MyPostingsInRecruitment;
+
+import java.util.List;
+
+public record MyPostingsInRecruitmentResponse(
+        List<MyPostingsInRecruitment> postings
+) {
+}

--- a/src/main/java/com/bookjob/job/facade/RecruitmentFacade.java
+++ b/src/main/java/com/bookjob/job/facade/RecruitmentFacade.java
@@ -1,0 +1,43 @@
+package com.bookjob.job.facade;
+
+import com.bookjob.common.exception.BadRequestException;
+import com.bookjob.job.dto.request.RecruitmentDeleteRequest;
+import com.bookjob.job.dto.request.RecruitmentIdsRequest;
+import com.bookjob.job.dto.response.MyPostingsInRecruitmentResponse;
+import com.bookjob.job.service.JobPostingWriteService;
+import com.bookjob.job.service.JobSeekingWriteService;
+import com.bookjob.job.service.RecruitmentService;
+import com.bookjob.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RecruitmentFacade {
+
+    private final RecruitmentService recruitmentService;
+    private final JobPostingWriteService jobPostingWriteService;
+    private final JobSeekingWriteService jobSeekingWriteService;
+
+    private final String CATEGORY_JOB_POSTING = "JOB_POSTING";
+    private final String CATEGORY_JOB_SEEKING = "JOB_SEEKING";
+
+    public MyPostingsInRecruitmentResponse getMyPostingsInRecruitments(Member member, int page, int limit) {
+        return recruitmentService.getMyPostingsInRecruitments(member, page, limit);
+    }
+
+    public void deleteMyPostingsInRecruitments(Member member, RecruitmentIdsRequest request) {
+        for(RecruitmentDeleteRequest deleteRequest: request.deleteRequest()) {
+            Long id = deleteRequest.recruitmentId();
+            String category = deleteRequest.recruitmentCategory();
+
+            if (CATEGORY_JOB_POSTING.equalsIgnoreCase(category)) {
+                jobPostingWriteService.deleteJobPosting(id, member);
+            } else if (CATEGORY_JOB_SEEKING.equalsIgnoreCase(category)) {
+                jobSeekingWriteService.deleteJobSeeking(id, member);
+            } else {
+                throw BadRequestException.invalidJobCategory(category);
+            }
+        }
+    }
+}

--- a/src/main/java/com/bookjob/job/repository/JobPostingQueryRepository.java
+++ b/src/main/java/com/bookjob/job/repository/JobPostingQueryRepository.java
@@ -1,10 +1,13 @@
 package com.bookjob.job.repository;
 
 import com.bookjob.job.domain.JobPostingOrder;
+import com.bookjob.job.dto.application.MyPostingsInRecruitment;
 import com.bookjob.job.dto.response.JobPostingPreviewResponse;
 
 import java.util.List;
 
 public interface JobPostingQueryRepository {
     List<JobPostingPreviewResponse> getJobPostingsOrderedBy(JobPostingOrder order, Long cursor, int size);
+
+    List<MyPostingsInRecruitment> findMyPostingsByMemberId(Long id, int page, int limit);
 }

--- a/src/main/java/com/bookjob/job/service/JobPostingWriteService.java
+++ b/src/main/java/com/bookjob/job/service/JobPostingWriteService.java
@@ -1,5 +1,6 @@
 package com.bookjob.job.service;
 
+import com.bookjob.common.exception.BadRequestException;
 import com.bookjob.common.exception.ForbiddenException;
 import com.bookjob.common.exception.NotFoundException;
 import com.bookjob.job.domain.EmploymentType;
@@ -76,6 +77,6 @@ public class JobPostingWriteService {
             throw ForbiddenException.forbidden();
         }
 
-        jobPostingRepository.delete(jobPosting);
+        jobPosting.softDelete();
     }
 }

--- a/src/main/java/com/bookjob/job/service/JobSeekingWriteService.java
+++ b/src/main/java/com/bookjob/job/service/JobSeekingWriteService.java
@@ -61,8 +61,10 @@ public class JobSeekingWriteService {
     public void deleteJobSeeking(Long id, Member member) {
         JobSeeking jobSeeking = jobSeekingRepository.findById(id).orElseThrow(NotFoundException::jobSeekingNotFound);
 
-        if (!jobSeeking.getMemberId().equals(member.getId())) {throw ForbiddenException.forbidden();}
+        if (!jobSeeking.getMemberId().equals(member.getId())) {
+            throw ForbiddenException.forbidden();
+        }
 
-        jobSeekingRepository.delete(jobSeeking);
+        jobSeeking.softDelete();
     }
 }

--- a/src/main/java/com/bookjob/job/service/RecruitmentService.java
+++ b/src/main/java/com/bookjob/job/service/RecruitmentService.java
@@ -1,0 +1,32 @@
+package com.bookjob.job.service;
+
+import com.bookjob.job.dto.application.MyPostingsInRecruitment;
+import com.bookjob.job.dto.response.MyPostingsInRecruitmentResponse;
+import com.bookjob.job.repository.JobPostingRepository;
+import com.bookjob.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecruitmentService {
+
+    private final JobPostingRepository jobPostingRepository;
+
+    public MyPostingsInRecruitmentResponse getMyPostingsInRecruitments(Member member, int page, int limit) {
+        List<MyPostingsInRecruitment> MyJobPostingsInRecruitment =
+                jobPostingRepository.findMyPostingsByMemberId(member.getId(), page, limit);
+
+        if (MyJobPostingsInRecruitment == null) {
+            MyJobPostingsInRecruitment = Collections.emptyList();
+        }
+
+        return new MyPostingsInRecruitmentResponse(MyJobPostingsInRecruitment);
+    }
+
+}

--- a/src/main/java/com/bookjob/member/controller/MemberController.java
+++ b/src/main/java/com/bookjob/member/controller/MemberController.java
@@ -41,17 +41,4 @@ public class MemberController {
         memberFacade.updateNickname(member, request);
         return ResponseEntity.ok(CommonResponse.success());
     }
-
-    @GetMapping("/boards")
-    public ResponseEntity<?> getMyPostingsInBoard(@AuthenticationPrincipal(expression = "member") Member member) {
-        MyPostingsInBoardResponse myPostingsInBoardResponse = memberFacade.getMyPostingsInBoard(member);
-        return ResponseEntity.ok(CommonResponse.success(myPostingsInBoardResponse));
-    }
-
-    @DeleteMapping("/boards")
-    public ResponseEntity<?> deleteMyPostingsInBoard(@AuthenticationPrincipal(expression = "member") Member member,
-                                                   @Valid @RequestBody BoardIdsRequest request) {
-        memberFacade.deleteMyPostingsInBoard(member, request);
-        return ResponseEntity.ok(CommonResponse.success());
-    }
 }

--- a/src/main/java/com/bookjob/member/facade/MemberFacade.java
+++ b/src/main/java/com/bookjob/member/facade/MemberFacade.java
@@ -16,8 +16,6 @@ public class MemberFacade {
     private final MemberWriteService memberWriteService;
     private final MemberReadService memberReadService;
     private final AuthService authService;
-    private final BoardReadService boardReadService;
-    private final BoardWriteService boardWriteService;
 
     public void saveMember(MemberSignupRequest request) {
         memberWriteService.registerMember(request);
@@ -34,13 +32,5 @@ public class MemberFacade {
     public void updateNickname(Member member, UpdateNicknameRequest request) {
         authService.checkDuplicatedNickname(request.nickname());
         memberWriteService.updateNickname(member, request);
-    }
-
-    public MyPostingsInBoardResponse getMyPostingsInBoard(Member member) {
-        return boardReadService.getMyPostingsInBoard(member);
-    }
-
-    public void deleteMyPostingsInBoard(Member member, BoardIdsRequest request) {
-        boardWriteService.deleteMyPostingsInBoard(member, request);
     }
 }

--- a/src/test/java/com/bookjob/job/domain/EmploymentTypeTest.java
+++ b/src/test/java/com/bookjob/job/domain/EmploymentTypeTest.java
@@ -31,7 +31,7 @@ class EmploymentTypeTest {
             // when & then
             assertThatThrownBy(() -> EmploymentType.fromString(invalidType))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage(BadRequestException.invalidEmployType(invalidType).getMessage());
+                    .hasMessage(BadRequestException.invalidEnumValue(invalidType, EmploymentType.class).getMessage());
         }
     }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- hard delete -> soft delete 변경
- 조회 시 구인/구직글 union all 후 pagination 적용
- member 에 속해 있던 '내가 쓴 자유게시판 글' 관련 내용을 board로 이동


## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET   | /api/v1/recruitments/members | 내가 쓴 구인구직글 조회        |
| DELETE   | /api/v1/recruitments/members | 내가 쓴 구인구직글 선택 삭제        |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
