### PR TITLE
From 55-refactor-비밀번호-수정용-토큰-및-상세조회-flag-추가 into dev

### DIFF
--- a/src/main/java/com/bookjob/auth/controller/AuthController.java
+++ b/src/main/java/com/bookjob/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.bookjob.auth.controller;
 
 import com.bookjob.auth.dto.FindLoginIdResponse;
 import com.bookjob.auth.dto.MaskedEmailResponse;
+import com.bookjob.auth.dto.TempTokenResponse;
 import com.bookjob.auth.facade.AuthFacade;
 import com.bookjob.common.dto.CommonResponse;
 import com.bookjob.email.dto.EmailRequest;
@@ -89,11 +90,11 @@ public class AuthController {
     }
 
     /**
-     * 비밀번호 찾기 시, 이메일 인증 요청
+     * 비밀번호 찾기 시, 임시 비밀번호 확인
      */
-    @PostMapping("/email-verification/pw/code")
+    @PostMapping("/email-verification/pw/temp")
     public ResponseEntity<?> verifyCodeForPassword(@Valid @RequestBody EmailVerificationRequest request) {
-        authFacade.verifyCodeForPassword(request);
-        return ResponseEntity.ok(CommonResponse.success());
+        String resetToken = authFacade.verifyCodeForPassword(request);
+        return ResponseEntity.ok(CommonResponse.success(new TempTokenResponse(resetToken)));
     }
 }

--- a/src/main/java/com/bookjob/auth/domain/entity/TemporaryToken.java
+++ b/src/main/java/com/bookjob/auth/domain/entity/TemporaryToken.java
@@ -1,0 +1,30 @@
+package com.bookjob.auth.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TemporaryToken {
+    @Id
+    private String token;
+
+    private String email;
+
+    private LocalDateTime expiresAt;
+
+    public TemporaryToken (String token, String email, LocalDateTime expiresAt) {
+        this.token = token;
+        this.email = email;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}
+

--- a/src/main/java/com/bookjob/auth/domain/repository/TemporaryTokenRepository.java
+++ b/src/main/java/com/bookjob/auth/domain/repository/TemporaryTokenRepository.java
@@ -1,0 +1,19 @@
+package com.bookjob.auth.domain.repository;
+
+import com.bookjob.auth.domain.entity.TemporaryToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+public interface TemporaryTokenRepository extends JpaRepository<TemporaryToken, String> {
+    boolean existsByTokenAndEmail(@Param("resetToken") String resetToken, @Param("email") String email);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM TemporaryToken t WHERE t.expiresAt < :now")
+    void deleteExpiredTokens(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/bookjob/auth/dto/TempTokenResponse.java
+++ b/src/main/java/com/bookjob/auth/dto/TempTokenResponse.java
@@ -1,0 +1,6 @@
+package com.bookjob.auth.dto;
+
+public record TempTokenResponse (
+        String resetToken
+) {
+}

--- a/src/main/java/com/bookjob/auth/facade/AuthFacade.java
+++ b/src/main/java/com/bookjob/auth/facade/AuthFacade.java
@@ -22,7 +22,7 @@ public class AuthFacade {
     }
 
     public void verifyCode(EmailVerificationRequest request) {
-        emailService.verifyCode(request);
+        emailService.verifyCodeAndDelete(request);
     }
 
     public void checkDuplicatedLoginId(String loginId) {
@@ -39,7 +39,7 @@ public class AuthFacade {
     }
 
     public String verifyCodeForLoginId(EmailVerificationRequest request) {
-        emailService.verifyCode(request);
+        emailService.verifyCodeAndDelete(request);
         return memberReadService.getMaskedLoginId(request.email());
     }
 
@@ -49,10 +49,13 @@ public class AuthFacade {
 
     public void sendCodeToEmailForPassword(String email) {
         authService.doesEmailExist(email);
-        emailService.requestEmailVerification(email, EmailReason.PASSWORD);
+        emailService.requestTemporaryPassword(email, EmailReason.PASSWORD);
     }
 
-    public void verifyCodeForPassword(EmailVerificationRequest request) {
-        emailService.verifyCode(request);
+    public String verifyCodeForPassword(EmailVerificationRequest request) {
+        String email = emailService.verifyCode(request);
+        String resetToken = authService.createTokenForChangePassword(email);
+        emailService.deleteFromEmailVerification(email);
+        return resetToken;
     }
 }

--- a/src/main/java/com/bookjob/auth/service/scheduler/AuthScheduler.java
+++ b/src/main/java/com/bookjob/auth/service/scheduler/AuthScheduler.java
@@ -1,0 +1,21 @@
+package com.bookjob.auth.service.scheduler;
+
+import com.bookjob.auth.domain.repository.TemporaryTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class AuthScheduler {
+
+    private final TemporaryTokenRepository temporaryTokenRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+    public void deleteExpiredTokens() {
+        LocalDateTime now = LocalDateTime.now();
+        temporaryTokenRepository.deleteExpiredTokens(now);
+    }
+}

--- a/src/main/java/com/bookjob/board/controller/BoardController.java
+++ b/src/main/java/com/bookjob/board/controller/BoardController.java
@@ -56,8 +56,9 @@ public class BoardController {
     }
 
     @GetMapping("/{boardId}")
-    public ResponseEntity<?> getBoard(@PathVariable Long boardId) {
-        BoardDetailResponse res = boardFacade.getBoardDetail(boardId);
+    public ResponseEntity<?> getBoard(@PathVariable Long boardId,
+                                      @AuthenticationPrincipal(expression = "member") Member member) {
+        BoardDetailResponse res = boardFacade.getBoardDetail(boardId, member);
 
         return ResponseEntity.ok(CommonResponse.success(res));
     }

--- a/src/main/java/com/bookjob/board/dto/response/BoardDetailResponse.java
+++ b/src/main/java/com/bookjob/board/dto/response/BoardDetailResponse.java
@@ -9,6 +9,7 @@ public record BoardDetailResponse(
         long commentCount,
         long viewCount,
         boolean isAuthentic,
+        boolean isWriter,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 ) {

--- a/src/main/java/com/bookjob/board/facade/BoardFacade.java
+++ b/src/main/java/com/bookjob/board/facade/BoardFacade.java
@@ -38,8 +38,8 @@ public class BoardFacade {
         boardWriteService.deleteBoard(boardId, member);
     }
 
-    public BoardDetailResponse getBoardDetail(Long boardId) {
-        return boardReadService.getBoardDetails(boardId);
+    public BoardDetailResponse getBoardDetail(Long boardId, Member member) {
+        return boardReadService.getBoardDetails(boardId, member.getId());
     }
 
     public List<BoardBestResponse> getBoardBest() {

--- a/src/main/java/com/bookjob/board/repository/BoardRepository.java
+++ b/src/main/java/com/bookjob/board/repository/BoardRepository.java
@@ -10,16 +10,24 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("""
             SELECT new com.bookjob.board.dto.response.BoardDetailResponse(
-            b.title, b.text, b.nickname, b.commentCount, b.viewCount, b.isAuthentic, b.createdAt, b.modifiedAt)
+            b.title,
+            b.text,
+            b.nickname,
+            b.commentCount,
+            b.viewCount,
+            b.isAuthentic,
+            CASE WHEN b.memberId = :memberId THEN true ELSE false END,
+            b.createdAt,
+            b.modifiedAt
+            )
             FROM Board b WHERE b.id = :id AND b.deletedAt IS NULL
             """)
-    Optional<BoardDetailResponse> findBoardById(@Param("id") Long id);
+    Optional<BoardDetailResponse> findBoardById(@Param("id") Long id, @Param("memberId") Long memberId);
 
     @Query("""
             SELECT new com.bookjob.member.dto.MyPostingsInBoard(

--- a/src/main/java/com/bookjob/board/service/BoardReadService.java
+++ b/src/main/java/com/bookjob/board/service/BoardReadService.java
@@ -49,8 +49,8 @@ public class BoardReadService {
         return new CursorBoardResponse(boards, lastBoardId);
     }
 
-    public BoardDetailResponse getBoardDetails(Long boardId) {
-        return boardRepository.findBoardById(boardId).orElseThrow(
+    public BoardDetailResponse getBoardDetails(Long boardId, Long memberId) {
+        return boardRepository.findBoardById(boardId, memberId).orElseThrow(
                 () -> NotFoundException.boardNotFound(boardId)
         );
     }

--- a/src/main/java/com/bookjob/common/exception/BadRequestException.java
+++ b/src/main/java/com/bookjob/common/exception/BadRequestException.java
@@ -14,6 +14,7 @@ public class BadRequestException extends BaseException {
     static private final String JOB_SEEKING_ALREADY_DELETED = "이미 삭제된 구직 글입니다.";
     static private final String BOARD_ALREADY_DELETED = "이미 삭제된 자유게시판 글입니다.";
     static private final String PASSWORD_MISMATCH = "비밀번호가 일치하지 않습니다.";
+    static private final String INVALID_RESET_TOKEN = "유효하지 않은 임시 토큰입니다.";
 
     public BadRequestException(String message) {
         super(message, HttpStatus.BAD_REQUEST);
@@ -53,7 +54,11 @@ public class BadRequestException extends BaseException {
         return new BadRequestException(BOARD_ALREADY_DELETED);
     }
 
-    public static BadRequestException passwordMissmatch() {
+    public static BadRequestException passwordMismatch() {
         return new BadRequestException(PASSWORD_MISMATCH);
+    }
+
+    public static BadRequestException invalidResetToken() {
+        return new BadRequestException(INVALID_RESET_TOKEN);
     }
 }

--- a/src/main/java/com/bookjob/member/controller/MemberController.java
+++ b/src/main/java/com/bookjob/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.bookjob.member.controller;
 
+import com.bookjob.auth.dto.TempTokenResponse;
 import com.bookjob.common.dto.CommonResponse;
 import com.bookjob.member.domain.Member;
 import com.bookjob.member.dto.OriginalPasswordRequest;
@@ -55,17 +56,17 @@ public class MemberController {
         return ResponseEntity.ok(CommonResponse.success());
     }
 
-    @GetMapping("/password")
+    @PostMapping("/password")
     public ResponseEntity<?> checkOriginalPassword(@AuthenticationPrincipal(expression = "member") Member member,
                                                    @RequestBody @Valid OriginalPasswordRequest request) {
-        memberFacade.checkOriginalPassword(member.getId(), request);
-        return ResponseEntity.ok(CommonResponse.success());
+        String resetToken = memberFacade.checkOriginalPassword(member, request);
+        return ResponseEntity.ok(CommonResponse.success(new TempTokenResponse(resetToken)));
     }
 
-    @PostMapping("/password")
+    @PostMapping("/password/change")
     public ResponseEntity<?> changePassword(@AuthenticationPrincipal(expression = "member") Member member,
                                                    @RequestBody @Valid ChangePasswordRequest request) {
-        memberFacade.changePassword(member.getId(), request);
+        memberFacade.changePassword(member, request);
         return ResponseEntity.ok(CommonResponse.success());
     }
 }

--- a/src/main/java/com/bookjob/member/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/bookjob/member/dto/request/ChangePasswordRequest.java
@@ -8,6 +8,9 @@ public record ChangePasswordRequest (
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d).+$", message = "비밀번호는 영문과 숫자를 포함해야 합니다.")
-        String password
+        String password,
+
+        @NotBlank
+        String resetToken
 ) {
 }

--- a/src/test/java/com/bookjob/board/service/BoardReadServiceTest.java
+++ b/src/test/java/com/bookjob/board/service/BoardReadServiceTest.java
@@ -116,14 +116,15 @@ public class BoardReadServiceTest {
         void 게시글_PK_로_상세_조회() {
             // given
             Long boardId = 1L;
+            Long memberId = 2L;
             BoardDetailResponse response = mock(BoardDetailResponse.class);
-            when(boardRepository.findBoardById(boardId)).thenReturn(Optional.of(response));
+            when(boardRepository.findBoardById(boardId, memberId)).thenReturn(Optional.of(response));
 
             // when
-            BoardDetailResponse boardDetails = boardReadService.getBoardDetails(boardId);
+            BoardDetailResponse boardDetails = boardReadService.getBoardDetails(boardId, memberId);
 
             // then
-            verify(boardRepository).findBoardById(boardId);
+            verify(boardRepository).findBoardById(boardId, memberId);
             assertThat(boardDetails).isEqualTo(response);
         }
 
@@ -131,11 +132,12 @@ public class BoardReadServiceTest {
         void 글이_존재하지_않을_때_NOTFOUND_반환() {
             // given
             Long wrongBoardId = 1L;
-            when(boardRepository.findBoardById(1L)).thenReturn(Optional.empty());
+            Long memberId = 2L;
+            when(boardRepository.findBoardById(1L, 2L)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> boardReadService.getBoardDetails(wrongBoardId)).isInstanceOf(NotFoundException.class);
-            verify(boardRepository).findBoardById(1L);
+            assertThatThrownBy(() -> boardReadService.getBoardDetails(wrongBoardId, memberId)).isInstanceOf(NotFoundException.class);
+            verify(boardRepository).findBoardById(1L, 2L);
         }
     }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 비밀번호 수정용 토큰 발급
- 자유게시판 상세 조회 시 isWriter flag 추가

## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
- 토큰은 UUID 발급. 비밀번호 수정 시 해당 토큰을 새로운 비밀번호와 함께 body에 담아 전달. 
- 토큰/이메일/만료일 을 담을 Temporary Token 테이블 생성. DDL 하단 첨부. 
- CREATE TABLE temporary_token (
                                 token VARCHAR(100) PRIMARY KEY,
                                 email VARCHAR(255) NOT NULL,
                                 expires_at DATETIME NOT NULL
);


## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
